### PR TITLE
Tweak - Email safe font family.

### DIFF
--- a/google-fonts.json
+++ b/google-fonts.json
@@ -14088,6 +14088,106 @@
         "regular": "http://fonts.gstatic.com/s/zillaslabhighlight/v6/gNMbW2BrTpK8-inLtBJgMMfbm6uNVDvRxhtIY2DwSXlM.ttf",
         "700": "http://fonts.gstatic.com/s/zillaslabhighlight/v6/gNMUW2BrTpK8-inLtBJgMMfbm6uNVDvRxiP0TET4YmVF0Mb6.ttf"
       }
+    },
+	{
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Arial",
+      "category": "serif",
+      "variants": ["regular", "700", "600italic","italic"],
+      "subsets": ["latin", "latin-ext"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Courier New",
+      "category": "monospace",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Georgia",
+      "category": "serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Lucida Sans Unicode",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Lucida Sans",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Helvetica",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Tahoma",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Times New Roman",
+      "category": "serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Trebuchet MS",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
+    },
+    {
+      "kind": "emailsafefonts#emailsafefont",
+      "family": "Verdana",
+      "category": "sans-serif",
+      "variants": ["regular", "bold", "italic", "bolditalic"],
+      "subsets": ["latin"],
+      "version": "system",
+      "lastModified": "2025-16-19",
+      "files": {}
     }
   ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds email safe fonts in the font json.

Closes # .

### How to test the changes in this Pull Request:

This font will be used in email template as email service provider such as gmail, outlook supports only email safe fonts.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Email safe font family.
